### PR TITLE
Typo, has_key.py2

### DIFF
--- a/chapter2/pythoinc/has_key.py2
+++ b/chapter2/pythoinc/has_key.py2
@@ -4,7 +4,7 @@
 #!/usr/bin/python2
 
 def main():
-    dic = {"korea":82, "japen":81}
+    dic = {"korea":82, "japan":81}
 
     print ("=== has_key ===")
     print (dic.has_key("korea"))


### PR DESCRIPTION
I found typo.
`japen` to `japan`